### PR TITLE
Enhance WebSocket reconnection logic with retry count and timeout

### DIFF
--- a/src/components/chat-messages.tsx
+++ b/src/components/chat-messages.tsx
@@ -24,8 +24,16 @@ export const ChatMessages: FC<ChatMessagesProps> = memo(({ hostname }) => {
   const shouldScrollRef = useRef(true);
 
   const wsUrl = `ws${isProd ? "s" : ""}://${hostname}/ws`;
-  const [messages, sendMessage, onlineCount, userId, isConnected, connect] =
-    useMessaging(() => wsUrl);
+  const [
+    messages,
+    sendMessage,
+    onlineCount,
+    userId,
+    isConnected,
+    connect,
+    retryCount,
+    maxRetries,
+  ] = useMessaging(() => wsUrl);
 
   useEffect(() => {
     const scrollArea = scrollAreaRef.current;
@@ -91,6 +99,8 @@ export const ChatMessages: FC<ChatMessagesProps> = memo(({ hostname }) => {
         onlineCount={onlineCount}
         isConnected={isConnected}
         onReconnect={connect}
+        retryCount={retryCount}
+        maxRetries={maxRetries}
       />
     </VStack>
   );

--- a/src/components/message-input.tsx
+++ b/src/components/message-input.tsx
@@ -17,10 +17,19 @@ interface MessageInputProps {
   onlineCount: number;
   isConnected: boolean;
   onReconnect: () => void;
+  retryCount: number;
+  maxRetries: number;
 }
 
 export const MessageInput: FC<MessageInputProps> = memo(
-  ({ sendMessage, onlineCount, isConnected, onReconnect }) => {
+  ({
+    sendMessage,
+    onlineCount,
+    isConnected,
+    onReconnect,
+    retryCount,
+    maxRetries,
+  }) => {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
     const handleSubmit = useCallback(async () => {
@@ -82,13 +91,16 @@ export const MessageInput: FC<MessageInputProps> = memo(
         ) : (
           <HStack gap="xs">
             <Center as={Tag} colorScheme="danger" w="fit-content">
-              Connection Disconnected
+              {retryCount > 0
+                ? `Reconnecting (${retryCount}/${maxRetries})...`
+                : "Connection Disconnected"}
             </Center>
             <IconButton
               onClick={onReconnect}
               variant="subtle"
               colorScheme="primary"
               size="xs"
+              loading={retryCount > 0}
             >
               <RefreshCwIcon />
             </IconButton>


### PR DESCRIPTION
Add retry count and max retries to WebSocket reconnection logic to improve reliability. Implement a connection timeout to prevent indefinite waiting. Update UI to display reconnection status and retry count. Clean up socket instances properly before reconnecting to avoid memory leaks and ensure consistent state.